### PR TITLE
Markdownプレビューの実装

### DIFF
--- a/app/controllers/markdown_controller.rb
+++ b/app/controllers/markdown_controller.rb
@@ -1,0 +1,8 @@
+class MarkdownController < ApplicationController
+  skip_before_action :authenticate_user
+
+  def preview
+    markdown = view_context.markdown(params[:body])
+    render json: { body: markdown }
+  end
+end

--- a/app/views/form_builder/_markdown.html.haml
+++ b/app/views/form_builder/_markdown.html.haml
@@ -1,0 +1,22 @@
+- errors_for_col = f.object.errors.full_messages_for(col)
+- placeholder = opts[:placeholder] || "Markdown記法が利用可能です。(チェックボックス、画像、リンク、絵文字は非対応)"
+- rows = opts[:rows] || 8
+.toggle-markdown-preview
+  .form-group.row.markdown-preview-container
+    = f.label col, class: 'col-sm-2 col-form-label'
+    .col-sm-10
+      .nav-active-white
+        %ul.nav.nav-tabs
+          %li.nav-item.mr-2
+            = link_to "編集画面", "#", class: "nav-link active markdown-edit-btn"
+          %li.nav-item
+            = link_to "プレビュー", "#", class: "nav-link markdown-preview-btn"
+      .markdown-edit-field
+        = f.text_area col, rows: rows, placeholder: placeholder, class: "form-control preview-body#{' is-invalid' if errors_for_col.present?} #{opts[:add_class]}", style: "border-radius: 0 .25rem .25rem .25rem;"
+        - if errors_for_col.empty? && opts[:message].present?
+          .form-text.text-muted.filled.text-sm.mt-1= opts[:message]
+        - else
+          - errors_for_col.each do |message|
+            %p.text-danger.filled.text-sm.mt-1= message
+      .markdown-preview-field{ style: "display: none;" }
+        .markdown-body

--- a/app/views/shared/_new_review_req_form.html.haml
+++ b/app/views/shared/_new_review_req_form.html.haml
@@ -13,7 +13,7 @@
             = form_for resource, url: url, html: { class: "review-req-form" } do |f|
               = f.hidden_field :is_open, value: true
               = f.text_parts :name, add_class: "review-req-name"
-              = f.textarea_parts :description, add_class: "review-req-description", placeholder: "Markdown記法が利用可能です。(チェックボックス、画像、リンク、絵文字は非対応)"
+              = f.markdown_parts :description, add_class: "review-req-description"
               = f.select_parts :room_id, options: room_collection, include_blank: "ルームを選択してください"
               = f.select_parts :pull_id, options: pull_collection, include_blank: "プルリクエストを選択してください", add_class: "pull-select"
               .action.text-center

--- a/app/views/users/rooms/_form.html.haml
+++ b/app/views/users/rooms/_form.html.haml
@@ -4,7 +4,7 @@
       - image_message = "推奨サイズは1250 × 300です"
       = f.image_parts :image, is_preview: true, button_text: "カバー画像を選択...", message: image_message
       = f.text_parts :name
-      = f.textarea_parts :description, placeholder: "Markdown記法が利用可能です。(チェックボックス、画像、リンク、絵文字は非対応)"
+      = f.markdown_parts :description
       = f.number_parts :capacity
       .form-group.row
         = label :skill, "レビュー言語", class: "col-sm-2 col-form-label"

--- a/app/views/users/rooms/review_requests/_edit_comment_form.html.haml
+++ b/app/views/users/rooms/review_requests/_edit_comment_form.html.haml
@@ -1,6 +1,17 @@
-.box.m-0.edit-comment-form
+.box.m-0.edit-comment-form.markdown-preview-container
+  .box-header.pb-0
+    .nav-active-white
+      %ul.nav.nav-tabs
+        %li.nav-item.mr-2
+          = link_to "編集画面", "#", class: "nav-link active markdown-edit-btn"
+        %li.nav-item
+          = link_to "プレビュー", "#", class: "nav-link markdown-preview-btn"
+  .box-divider.m-0
   = form_for comment, url: users_review_comment_path(comment), method: :patch do |f|
-    = f.text_area :body, rows: 5, placeholder: "コメントを入力...", class: "edit-comment-body form-control no-border"
+    .markdown-edit-field
+      = f.text_area :body, rows: 5, placeholder: "Markdown記法が利用可能です。(チェックボックス、画像、リンク、絵文字は非対応)", class: "edit-comment-body preview-body form-control no-border"
+    .box-body.markdown-preview-field{ style: "display: none;" }
+      .markdown-body.no-border
     .box-divider.m-0
     .box-footer.clearfix
       .text-danger.text-sm.invalid-comment コメント内容を入力してください

--- a/app/views/users/rooms/review_requests/show.html.haml
+++ b/app/views/users/rooms/review_requests/show.html.haml
@@ -59,12 +59,23 @@
                   = markdown comment.body
     .sl-item
       .sl-left= image_tag current_user.check_and_return_image(:thumb), class: "circle"
-      .sl-content
+      .sl-content.toggle-markdown-preview
         .box.m-0
+          .box-header.pb-0
+            .nav-active-white
+              %ul.nav.nav-tabs
+                %li.nav-item.mr-2
+                  = link_to "編集画面", "#", class: "nav-link active markdown-edit-btn"
+                %li.nav-item
+                  = link_to "プレビュー", "#", class: "nav-link markdown-preview-btn"
+          .box-divider.m-0
           = form_for @review_comment, url: users_review_comments_path do |f|
             = f.hidden_field :review_request_id, value: @review_req.id
-            - error_for_col = f.object.errors.full_messages_for(:body)
-            = f.text_area :body, rows: 5, placeholder: "Markdown記法が利用可能です。(チェックボックス、画像、リンク、絵文字は非対応)", class: "form-control no-border #{'is-invalid' if error_for_col.present?}"
+            .markdown-edit-field
+              - error_for_col = f.object.errors.full_messages_for(:body)
+              = f.text_area :body, rows: 5, placeholder: "Markdown記法が利用可能です。(チェックボックス、画像、リンク、絵文字は非対応)", class: "form-control no-border preview-body #{'is-invalid' if error_for_col.present?}"
+            .box-body.markdown-preview-field{ style: "display: none;" }
+              .markdown-body.no-border
             .box-divider.m-0
             .box-footer.clearfix
               - error_for_col.each do |message|

--- a/app/views/users/rooms/review_requests/show.html.haml
+++ b/app/views/users/rooms/review_requests/show.html.haml
@@ -1,4 +1,4 @@
-.padding
+.padding.toggle-markdown-preview
   .box
     .box-header.navbar
       %h2
@@ -59,8 +59,8 @@
                   = markdown comment.body
     .sl-item
       .sl-left= image_tag current_user.check_and_return_image(:thumb), class: "circle"
-      .sl-content.toggle-markdown-preview
-        .box.m-0
+      .sl-content
+        .box.m-0.markdown-preview-container
           .box-header.pb-0
             .nav-active-white
               %ul.nav.nav-tabs

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -5,7 +5,7 @@ class ActionView::Helpers::FormBuilder
   CONTROLLER.instance_eval { @_request = Hashie::Mash.new }
   attr_accessor :output_buffer
 
-  FILES = %w[text textarea select number image].freeze
+  FILES = %w[text textarea markdown select number image].freeze
   FILES.each do |file|
     define_method "#{file}_parts" do |name, opts = {}|
       CONTROLLER.render_to_string(partial: "form_builder/#{file}", locals: { col: name, f: self, opts: opts })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,4 +38,5 @@ Rails.application.routes.draw do
   end
 
   post "/hooks/pulls", to: "hooks#pulls"
+  post "/markdown/preview", to: "markdown#preview"
 end

--- a/frontend/javascripts/application.js
+++ b/frontend/javascripts/application.js
@@ -8,6 +8,7 @@ import EditComment from './users/rooms/review_comments/edit_comment';
 import InitModal from './users/top/init_modal';
 import InsertPullInfo from './users/rooms/review_requests/insert_pull_info';
 import PreviewImage from './util/preview_image';
+import ToggleMarkdownPreview from './util/toggle_markdown_preview';
 
 document.addEventListener("DOMContentLoaded", () => {
   if($(".select2")[0]) { $(".select2").select2(); }
@@ -15,6 +16,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if($(".first-time-user")[0]) { new InitModal($(".first-time-user")); }
   if($(".review-req-form")[0]) { new InsertPullInfo($(".review-req-form")); }
   if($(".preview-image")[0]) { new PreviewImage($(".preview-image")); }
+  if($(".toggle-markdown-preview")[0]) { new ToggleMarkdownPreview($(".toggle-markdown-preview")); }
 });
 
 $(window).on("resize", function() {

--- a/frontend/javascripts/util/toggle_markdown_preview.js
+++ b/frontend/javascripts/util/toggle_markdown_preview.js
@@ -1,0 +1,54 @@
+export default class ToggleMarkdownPreview {
+  constructor($root) {
+    this.$root = $root;
+    this.beforeBody = '';
+    this.bind();
+  }
+
+  showMarkdownEdit(e) {
+    e.preventDefault();
+    const $editBtn = $(e.target);
+    const $root = $editBtn.closest('.toggle-markdown-preview');
+    const $editField = $root.find('.markdown-edit-field');
+    const $previewBtn = $root.find('.markdown-preview-btn');
+    const $previewField = $root.find('.markdown-preview-field');
+
+    $editBtn.addClass('active');
+    $editField.show();
+    $previewBtn.removeClass('active')
+    $previewField.hide();
+  }
+
+  showMarkdownPreview(e) {
+    e.preventDefault();
+    const $previewBtn = $(e.target);
+    const $root = $previewBtn.closest('.toggle-markdown-preview');
+    const $previewField = $root.find('.markdown-preview-field');
+    const $editBtn = $root.find('.markdown-edit-btn');
+    const $editField = $root.find('.markdown-edit-field');
+
+    $previewBtn.addClass('active');
+    $previewField.show();
+    $editBtn.removeClass('active');
+    $editField.hide();
+  }
+
+  async fetchMarkdownPreview(e) {
+    const $root = $(e.target).closest('.toggle-markdown-preview');
+    const previewBody = $root.find('.preview-body').val();
+    if (previewBody === this.beforeBody) return;
+
+    this.beforeBody = previewBody;
+    const token = $('meta[name="csrf_token"]').attr('content');
+    const path = '/markdown/preview';
+    const params = { body: previewBody, authenticity_token: token };
+    const markdown = await $.post(path, params);
+    $root.find('.markdown-body').html(markdown["body"]);
+  }
+
+  bind() {
+    this.$root.on('click', '.markdown-edit-btn', this.showMarkdownEdit);
+    this.$root.on('click', '.markdown-preview-btn', this.showMarkdownPreview);
+    this.$root.on('mouseover', '.markdown-preview-btn', this.fetchMarkdownPreview);
+  }
+}

--- a/frontend/javascripts/util/toggle_markdown_preview.js
+++ b/frontend/javascripts/util/toggle_markdown_preview.js
@@ -8,10 +8,10 @@ export default class ToggleMarkdownPreview {
   showMarkdownEdit(e) {
     e.preventDefault();
     const $editBtn = $(e.target);
-    const $root = $editBtn.closest('.toggle-markdown-preview');
-    const $editField = $root.find('.markdown-edit-field');
-    const $previewBtn = $root.find('.markdown-preview-btn');
-    const $previewField = $root.find('.markdown-preview-field');
+    const $container = $editBtn.closest('.markdown-preview-container');
+    const $editField = $container.find('.markdown-edit-field');
+    const $previewBtn = $container.find('.markdown-preview-btn');
+    const $previewField = $container.find('.markdown-preview-field');
 
     $editBtn.addClass('active');
     $editField.show();
@@ -22,10 +22,10 @@ export default class ToggleMarkdownPreview {
   showMarkdownPreview(e) {
     e.preventDefault();
     const $previewBtn = $(e.target);
-    const $root = $previewBtn.closest('.toggle-markdown-preview');
-    const $previewField = $root.find('.markdown-preview-field');
-    const $editBtn = $root.find('.markdown-edit-btn');
-    const $editField = $root.find('.markdown-edit-field');
+    const $container = $previewBtn.closest('.markdown-preview-container');
+    const $previewField = $container.find('.markdown-preview-field');
+    const $editBtn = $container.find('.markdown-edit-btn');
+    const $editField = $container.find('.markdown-edit-field');
 
     $previewBtn.addClass('active');
     $previewField.show();
@@ -34,8 +34,8 @@ export default class ToggleMarkdownPreview {
   }
 
   async fetchMarkdownPreview(e) {
-    const $root = $(e.target).closest('.toggle-markdown-preview');
-    const previewBody = $root.find('.preview-body').val();
+    const $container = $(e.target).closest('.markdown-preview-container');
+    const previewBody = $container.find('.preview-body').val();
     if (previewBody === this.beforeBody) return;
 
     this.beforeBody = previewBody;
@@ -43,7 +43,7 @@ export default class ToggleMarkdownPreview {
     const path = '/markdown/preview';
     const params = { body: previewBody, authenticity_token: token };
     const markdown = await $.post(path, params);
-    $root.find('.markdown-body').html(markdown["body"]);
+    $container.find('.markdown-body').html(markdown["body"]);
   }
 
   bind() {

--- a/frontend/stylesheets/style.sass
+++ b/frontend/stylesheets/style.sass
@@ -2,7 +2,7 @@
 .markdown-body
   font-size: 14px
   color: #465a6ed9
-  border: 1px solid lightgray
+  border: 1px solid rgba(120,130,140,.2)
   padding: 15px 20px
   margin-bottom: 20px
   &.no-border


### PR DESCRIPTION
## Markdownのプレビュー機能の実装
- プレビューのDOMはプレビューボタンにマウスオーバーした際に切り替わるように実装
- JSのコードはutil化して使い回せるようにした